### PR TITLE
Fix xmllint suppress

### DIFF
--- a/classes/sca-xmllint-core.bbclass
+++ b/classes/sca-xmllint-core.bbclass
@@ -21,7 +21,7 @@ def do_sca_conv_xmllint(d):
     package_name = d.getVar("PN")
     buildpath = d.getVar("SCA_SOURCES_DIR")
 
-    pattern = r"^(?P<file>.*):(?P<line>\d+):\s+(?P<id>.*)\s+:\s+(?P<msg>.*)"
+    pattern = r"^(?P<file>.*):(?P<line>\d+):\s+(?P<id>.*)\s+error\s+:\s+(?P<msg>.*)"
 
     _suppress = get_suppress_entries(d)
     _findings = []


### PR DESCRIPTION
The xmllint tool generates error messages on the form 'validity error', which are transformed into datamodel id's of 'xmllint.xmllint.validity error'.

The embedded space in the id strings makes it impossible to suppress error messages with SCA_XMLLINT_EXTRA_SUPPRESS.

Change the regex to not capture the trailing ' error' from the xmllint output, which will make it possible to suppress xmllint warnings.