### PR TITLE
Fix importlib-metadata depends on typing-extensions

### DIFF
--- a/recipes-python/python-flake8-native/python3-flake8-native_3.8.4.bb
+++ b/recipes-python/python-flake8-native/python3-flake8-native_3.8.4.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=75b26781f1adf1aa310bda6098937878"
 
 DEPENDS += "\
             ${PYTHON_PN}-entrypoints-native \
+            ${PYTHON_PN}-importlib-metadata-native \
             ${PYTHON_PN}-mccabe-native \
             ${PYTHON_PN}-pycodestyle-native \
             ${PYTHON_PN}-pyflakes-native \

--- a/recipes-python/python-importlib-metadata-native/python3-importlib-metadata-native_3.3.0.bb
+++ b/recipes-python/python-importlib-metadata-native/python3-importlib-metadata-native_3.3.0.bb
@@ -4,7 +4,10 @@ HOMEPAGE = "https://importlib-metadata.readthedocs.io/en/latest/"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e88ae122f3925d8bde8319060f2ddb8e"
 
-DEPENDS += "${PYTHON_PN}-zipp-native"
+DEPENDS += "\
+           ${PYTHON_PN}-typing-extensions-native \
+           ${PYTHON_PN}-zipp-native \
+           "
 
 PYPI_PACKAGE = "importlib_metadata"
 


### PR DESCRIPTION
When building a package that required importlib-metadata-native I got the following warning:
| pkg_resources.DistributionNotFound: The 'typing-extensions>=3.6.4' distribution was not found and is required by importlib-metadata

Add typing-extensions as a depends of importlib-metadata