### PR TITLE
Fix Flake8 depends on importlib-metadata

### DIFF
--- a/recipes-python/python-flake8-native/python3-flake8-native_3.8.4.bb
+++ b/recipes-python/python-flake8-native/python3-flake8-native_3.8.4.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=75b26781f1adf1aa310bda6098937878"
 
 DEPENDS += "\
             ${PYTHON_PN}-entrypoints-native \
+            ${PYTHON_PN}-importlib-metadata-native \
             ${PYTHON_PN}-mccabe-native \
             ${PYTHON_PN}-pycodestyle-native \
             ${PYTHON_PN}-pyflakes-native \


### PR DESCRIPTION
When building Flake8 native I got the following warning:
| pkg_resources.DistributionNotFound: The 'importlib-metadata' distribution was not found and is required by flake8

Add importlib-metadata as a dependency of flake8