### PR TITLE
add sonarqube compatible output format

### DIFF
--- a/classes/sca-conv-dm-sonarqube.bbclass
+++ b/classes/sca-conv-dm-sonarqube.bbclass
@@ -1,0 +1,62 @@
+## SPDX-License-Identifier: BSD-2-Clause
+## Copyright (c) 2021, Pascal Bach
+## Copyright (c) 2021, Siemens AG
+
+# Full format description to be found at https://docs.sonarqube.org/latest/analysis/generic-issue/
+
+inherit sca-datamodel
+
+def sca_conv_dm_sonarqube(d, tool):
+    import json
+    import os
+    import stat
+    import shutil
+
+    _items = sca_get_datamodel(d, d.getVar("SCA_DATAMODEL_STORAGE"))
+
+    _sev_map = {
+        "error": "MAJOR",
+        "warning": "MINOR",
+        "info": "INFO"
+    }
+
+    res = {"issues": []}
+
+    for i in _items:
+        _srcname = i.GetPath()
+        if d.getVar("SCA_EXPORT_FINDING_SRC") == "1":
+            _fname = i.GetPath(exportPath=d.getVar("SCA_EXPORT_FINDING_DIR"))
+            if os.path.exists(_srcname) and not os.path.exists(_fname):
+                os.makedirs(os.path.dirname(_fname), exist_ok=True)
+                try:
+                    shutil.copy(_srcname, _fname)
+                except Exception as e:
+                    bb.note("SCA_EXPORT_FINDING_SRC-error: {}".format(e))
+        else:
+            _fname = _srcname
+
+        _sub = {
+            "engineId": tool,
+            "ruleId": i.GetFormattedID(),
+            "primaryLocation": {
+                "message": i.Message,
+                "filePath": _fname,
+                "textRange" : {
+                    "startLine": int(i.Line),
+                    "startColumn": int(i.Column)
+                },
+            }
+        }
+        if i.Scope in ["security"]:
+            _sub["type"] = "VULNERABILITY"
+        elif i.Scope in ["functional"]:
+            _sub["type"] = "BUG"
+        else:
+            # Map everything else to CODE_SMELL
+            _sub["type"] = "CODE_SMELL"
+
+        _sub["severity"] = _sev_map[i.Severity]
+
+        res["issues"].append(_sub)
+
+    return json.dumps(res)

--- a/classes/sca-global.bbclass
+++ b/classes/sca-global.bbclass
@@ -30,6 +30,7 @@ SCA_EXPORT_FORMAT_SUFFIX_console = "txt"
 SCA_EXPORT_FORMAT_SUFFIX_diff = "txt"
 SCA_EXPORT_FORMAT_SUFFIX_stat = "json"
 SCA_EXPORT_FORMAT_SUFFIX_sarif = "sarif"
+SCA_EXPORT_FORMAT_SUFFIX_sonarqube = "json"
 SCA_EXPORT_FORMAT_SUFFIX_plain = "txt"
 # here for backward compatibility
 SCA_EXPORT_FORMAT_SUFFIX_codeclimate = "json"

--- a/docs/conf/global.md
+++ b/docs/conf/global.md
@@ -20,7 +20,7 @@ The behavior of the analysis can be controlled by several __bitbake__-variables
 | SCA_EXPORT_DIR | Directory where to store the results of analysis | path | \${DEPLOY_DIR_IMAGE}/sca
 | SCA_EXPORT_FINDING_DIR | The folder where to store the original source-files of findings | path | \${DEPLOY_DIR_IMAGE}/sca/sources/\${PN}/
 | SCA_EXPORT_FINDING_SRC | Do copy the source-files of any finding to deploy-dir. This proved to helpful when integrating into Jenkins. | string | "1"
-| SCA_EXPORT_FORMAT | Specifies the output format | string: checkstyle, console, diff, stat or sarif or plain| "checkstyle"
+| SCA_EXPORT_FORMAT | Specifies the output format | string: checkstyle, console, diff, stat or sarif, sonarqube or plain| "checkstyle"
 | SCA_FILE_FILTER | List of glob-expression of file to skip for testing | space separated list | "tests/* test/* doc/* testsuite/* \*\*/tests/* \*\*/test/* \*\*/doc/* \*\*/testsuite/*"
 | SCA_FINDINGS_DIR | Local folder where to store sca findings | path | \${WORKDIR}/sca/
 | SCA_FORCE_RUN | Force running SCA every time, no matter if recipe code was changed  | string: "0" or "1" | "0"

--- a/docs/conf/output_formats.md
+++ b/docs/conf/output_formats.md
@@ -8,6 +8,7 @@ Currently supported are
 * diff
 * stat
 * sarif
+* sonarqube
 * plain
 
 ## Checkstyle format
@@ -87,6 +88,10 @@ The complete format is described [here](https://github.com/fulldecent/structured
 
 This export format is compatible to [SARIF](https://sarifweb.azurewebsites.net/#Specification).
 It is a JSON file based on the this [json schema](https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json)
+
+## sonarqube format
+
+Exports the issues as a SonarQube generic import format as described on https://docs.sonarqube.org/latest/analysis/generic-issue/.
 
 ## plain format
 


### PR DESCRIPTION
Allows to export finding in a [format](https://docs.sonarqube.org/latest/analysis/generic-issue/) compatible with sonarqube.

I tested it on dunfell with "cppcheck" and "gcc" against SonarQube 7.x.

