### PR TITLE
revert mccabe bump to 0.7.0 as it's not compatible with flake8

### DIFF
--- a/recipes-python/python-mccabe-native/python3-mccabe-native_0.6.1.bb
+++ b/recipes-python/python-mccabe-native/python3-mccabe-native_0.6.1.bb
@@ -9,8 +9,8 @@ DEPENDS += "python3-pytest-runner-native"
 
 PYPI_PACKAGE = "mccabe"
 
-SRC_URI[md5sum] = "374ee2b9407546bb41d195e7436e5f62"
-SRC_URI[sha256sum] = "348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"
+SRC_URI[md5sum] = "723df2f7b1737b8887475bac4c763e1e"
+SRC_URI[sha256sum] = "dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
 
 inherit pypi
 inherit setuptools3


### PR DESCRIPTION
This reverts commit bf1e8f126b9c1447e6d8c2643263627760688fbe.

as flake8 0.4.1 require mccabe < 0.7.0 see https://github.com/PyCQA/flake8/blob/4.0.1/setup.cfg#L42