### PR TITLE
Kirkstone+cbmc native checkbashism native update

### DIFF
--- a/recipes-sca/cbmc-native/cbmc-native_5.90.0.bb
+++ b/recipes-sca/cbmc-native/cbmc-native_5.90.0.bb
@@ -18,7 +18,7 @@ SRC_URI = "\
     file://0001-diable-goto-gcc-regression-tests.patch \
 "
 
-SRCREV = "598c3dac53c56ebdbb4d726d4093856301732930"
+SRCREV = "6f1454272b7dffc4e37dc969d65653e69c14f904"
 SRC_URI[minisat2.sha256sum] = "e54afa3c192c1753bc8075c0c7e126d5c495d9066e3f90a2588091149ac9ca40"
 
 UPSTREAM_CHECK_GITTAGREGEX = "cbmc-(?P<pver>[\d\.a-f]+)"

--- a/recipes-sca/cbmc-native/files/0001-diable-goto-gcc-regression-tests.patch
+++ b/recipes-sca/cbmc-native/files/0001-diable-goto-gcc-regression-tests.patch
@@ -1,4 +1,4 @@
-From 5e8ed1940983f1eed4cf039ed118bf8ab07fea2a Mon Sep 17 00:00:00 2001
+From 5f01c36ac82f57c1c98ed146a6206cb70415065d Mon Sep 17 00:00:00 2001
 From: Konrad Weihmann <kweihmann@outlook.com>
 Date: Wed, 10 Feb 2021 15:24:11 +0100
 Subject: [PATCH] diable goto-gcc regression tests
@@ -7,23 +7,21 @@ as they keep failing for unknown reasons
 
 Upstream-Status: Inappropriate [disable feature]
 Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>
+
 ---
  regression/CMakeLists.txt | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/regression/CMakeLists.txt b/regression/CMakeLists.txt
-index c94edda39..4a58ec1df 100644
+index d337bd05c0..67e8750008 100644
 --- a/regression/CMakeLists.txt
 +++ b/regression/CMakeLists.txt
-@@ -41,7 +41,7 @@ add_subdirectory(goto-diff)
- add_subdirectory(test-script)
- add_subdirectory(goto-analyzer-taint)
+@@ -58,7 +58,7 @@ add_subdirectory(goto-bmc/goto-bmc-symex-ready-goto)
+ add_subdirectory(goto-bmc/goto-bmc-non-symex-ready-goto)
+ add_subdirectory(goto-bmc)
  if(NOT WIN32)
 -  add_subdirectory(goto-gcc)
 +  # add_subdirectory(goto-gcc)
  else()
    add_subdirectory(goto-cl)
  endif()
--- 
-2.25.1
-

--- a/recipes-sca/checkbashism-native/checkbashism-native_2.23.5.bb
+++ b/recipes-sca/checkbashism-native/checkbashism-native_2.23.5.bb
@@ -12,9 +12,9 @@ SRC_URI:append = " \
     file://checkbashism.sca.description \
 "
 
-SRC_URI[sha256sum] = "35dd5e6029d27be35b96e8c6e38b8aa6fba791a21371dac2de0f8cdee5fe33d5"
+SRC_URI[sha256sum] = "8f47d45534bf94f28576078c864b22273dbe139928074ec82b6b848f9e44586d"
 
-S = "${WORKDIR}/devscripts-${PV}"
+S = "${WORKDIR}/devscripts"
 UPSTREAM_CHECK_REGEX = "devscripts_(?P<pver>\d+\.\d+\.\d+)"
 
 inherit sca-description
@@ -35,3 +35,4 @@ do_install() {
 }
 
 FILES:${PN} += "${bindir}"
+


### PR DESCRIPTION
Hi Konrad

This is a PR request to merge to kirkstone.  It cherry-picks and slightly modifies (merge conflicts and patch refresh)  2 of your commits from master to fix two issues on kirkstone builds:

1. cbmc-native upgrade to 5.90 : The kirkstone version does not compile with GCC 12.2.0 (Debian 12 build host).
2. checkbashism-native upgrade to 2.35.5: The 2.22.1 devscripts source tarball called out in the kirskstone recipe is no longer hosted on the Debian SRC_URI.

Using the master meta-sca layer with kirkstone is no viable since it relies on python_hatchling.bblcass from the meta layer and its dependencies that are not in kirkstone  

Best Regards,
Geoff