### PR TITLE
kirkstone-backport: fix sca-helper: ignore all non existing files 

### DIFF
--- a/classes/sca-bandit-core.bbclass
+++ b/classes/sca-bandit-core.bbclass
@@ -30,7 +30,7 @@ def do_sca_conv_bandit(d):
     }
 
     _findings = []
-    _suppress = sca_suppress_init(d, "SCA_BANDIT_EXTRA_FATAL",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_BANDIT_EXTRA_SUPPRESS"),
                     d.expand("${STAGING_DATADIR_NATIVE}/bandit-${SCA_MODE}-suppress"))
 
     if os.path.exists(sca_raw_result_file(d, "bandit")):
@@ -110,6 +110,6 @@ python do_sca_bandit_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "bandit", get_fatal_entries(d, "SCA_BANDIT_EXTRA_SUPPRESS",
+    sca_task_aftermath(d, "bandit", get_fatal_entries(d, clean_split(d, "SCA_BANDIT_EXTRA_SUPPRESS"),
                         d.expand("${STAGING_DATADIR_NATIVE}/bandit-${SCA_MODE}-fatal")))
 }

--- a/classes/sca-bashate-core.bbclass
+++ b/classes/sca-bashate-core.bbclass
@@ -44,7 +44,7 @@ def do_sca_conv_bashate(d):
     }
 
     _findings = []
-    _suppress = sca_suppress_init(d, "SCA_BASHATE_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_BASHATE_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/bashate-${SCA_MODE}-suppress"))
 
     if os.path.exists(sca_raw_result_file(d, "bashate")):
@@ -97,7 +97,7 @@ python do_sca_bashate_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "bashate", get_fatal_entries(d, "SCA_BASHATE_EXTRA_FATAL",
+    sca_task_aftermath(d, "bashate", get_fatal_entries(d, clean_split(d, "SCA_BASHATE_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/bashate-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-bitbake-core.bbclass
+++ b/classes/sca-bitbake-core.bbclass
@@ -133,7 +133,7 @@ python do_sca_bitbake () {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "bitbake", get_fatal_entries(d, "", None))
+    sca_task_aftermath(d, "bitbake", get_fatal_entries(d, clean_split(d, ""), None))
 }
 
 DEPENDS += "bitbake-sca-native"

--- a/classes/sca-cbmc.bbclass
+++ b/classes/sca-cbmc.bbclass
@@ -52,7 +52,7 @@ def do_sca_conv_cbmc(d):
         "INFO" : "info"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_CBMC_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_CBMC_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/cbmc-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -148,7 +148,7 @@ python do_sca_cbmc_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "cbmc", get_fatal_entries(d, "SCA_CBMC_EXTRA_FATAL",
+    sca_task_aftermath(d, "cbmc", get_fatal_entries(d, clean_split(d, "SCA_CBMC_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/cbmc-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-checkbashism-core.bbclass
+++ b/classes/sca-checkbashism-core.bbclass
@@ -26,7 +26,7 @@ def do_sca_conv_checkbashism(d):
 
     pattern = r"^possible\sbashism\sin\s(?P<file>.*)\sline\s(?P<line>\d+)\s\((?P<id>.*)\)"
 
-    __suppress = sca_suppress_init(d, "SCA_CHECKBASHISM_EXTRA_SUPPRESS",
+    __suppress = sca_suppress_init(d, clean_split(d, "SCA_CHECKBASHISM_EXTRA_SUPPRESS"),
                                    d.expand("${STAGING_DATADIR_NATIVE}/checkbashism-${SCA_MODE}-suppress"))
     _findings = []
     if os.path.exists(sca_raw_result_file(d, "checkbashism")):
@@ -81,7 +81,7 @@ python do_sca_checkbashism_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "checkbashism", get_fatal_entries(d, "SCA_CHECKBASHISM_EXTRA_FATAL",
+    sca_task_aftermath(d, "checkbashism", get_fatal_entries(d, clean_split(d, "SCA_CHECKBASHISM_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/checkbashism-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-checksec-image.bbclass
+++ b/classes/sca-checksec-image.bbclass
@@ -40,7 +40,7 @@ def do_sca_conv_checksec(d):
     package_name = d.getVar("PN")
     buildpath = d.getVar("SCA_SOURCES_DIR")
 
-    _suppress = sca_suppress_init(d, "SCA_CHECKSEC_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_CHECKSEC_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/checksec-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -100,9 +100,10 @@ fakeroot python do_sca_checksec() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "checksec", get_fatal_entries(d, "SCA_CHECKSEC_EXTRA_FATAL",
+    sca_task_aftermath(d, "checksec", get_fatal_entries(d, clean_split(d, "SCA_CHECKSEC_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/checksec-${SCA_MODE}-fatal")))
 }
 
 do_sca_checksec[doc] = "Find security weaknesses in binaries"
+do_sca_checksec[nosdkgen] = "1"
 addtask do_sca_checksec before do_sca_deploy after do_image

--- a/classes/sca-cmake.bbclass
+++ b/classes/sca-cmake.bbclass
@@ -42,7 +42,7 @@ def do_sca_conv_cmake(d):
         "Deprecation Warning": "warning",
     }
 
-    _suppress = sca_suppress_init(d, "SCA_CMAKE_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_CMAKE_EXTRA_SUPPRESS"),
                                     d.expand("${STAGING_DATADIR_NATIVE}/cmake-${SCA_MODE}-suppress"))
     _excludes = sca_filter_files(d, d.getVar("SCA_SOURCES_DIR"), clean_split(d, "SCA_FILE_FILTER_EXTRA"))
     _findings = []
@@ -89,7 +89,7 @@ python do_sca_cmake_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "cmake", get_fatal_entries(d, "SCA_CMAKE_EXTRA_FATAL",
+    sca_task_aftermath(d, "cmake", get_fatal_entries(d, clean_split(d, "SCA_CMAKE_EXTRA_FATAL"),
                          d.expand("${STAGING_DATADIR_NATIVE}/cmake-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-configcheck-image.bbclass
+++ b/classes/sca-configcheck-image.bbclass
@@ -71,7 +71,7 @@ fakeroot python do_sca_configcheck() {
     cmd_output = ""
 
     _raw_findings = []
-    _suppress = sca_suppress_init(d, "SCA_CONFIGCHECK_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_CONFIGCHECK_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/configcheck-${SCA_MODE}-suppress"))
 
     _pargs = []
@@ -117,11 +117,12 @@ fakeroot python do_sca_configcheck() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "configcheck", get_fatal_entries(d, "SCA_TIGER_EXTRA_FATAL",
+    sca_task_aftermath(d, "configcheck", get_fatal_entries(d, clean_split(d, "SCA_TIGER_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/configcheck-${SCA_MODE}-fatal")))
 }
 
 do_sca_configcheck[doc] = "Check configuration of tools for validity in image"
+do_sca_configcheck[nosdkgen] = "1"
 addtask do_sca_configcheck before do_sca_deploy after do_image
 
 DEPENDS += "configcheck-sca-native sca-image-configcheck-rules-native"

--- a/classes/sca-cppcheck.bbclass
+++ b/classes/sca-cppcheck.bbclass
@@ -63,7 +63,7 @@ def do_sca_conv_cppcheck(d):
     }
 
     _findings = []
-    _suppress = sca_suppress_init(d, "SCA_CPPCHECK_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_CPPCHECK_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/cppcheck-${SCA_MODE}-suppress"))
 
     if os.path.exists(sca_raw_result_file(d, "cppcheck")):
@@ -108,6 +108,14 @@ python do_sca_cppcheck() {
     _add_include = d.getVar("SCA_CPPCHECK_ADD_INCLUDES").split(" ")
 
     # Copy configurations into special dir
+    try:
+        os.unlink(d.expand("${T}/cfg"))
+    except:
+        pass
+    try:
+        os.unlink(d.expand("${T}/platform"))
+    except:
+        pass
     subprocess.check_call(["ln", "-sf", d.expand("${STAGING_DATADIR_NATIVE}/cfg"), d.expand("${T}/cfg")])
     subprocess.check_call(["ln", "-sf", d.expand("${STAGING_DATADIR_NATIVE}/platform"), d.expand("${T}/platform")])
 
@@ -164,7 +172,7 @@ python do_sca_cppcheck_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "cppcheck", get_fatal_entries(d, d.getVar("SCA_CPPCHECK_EXTRA_FATAL"),
+    sca_task_aftermath(d, "cppcheck", get_fatal_entries(d, clean_split(d, "SCA_CPPCHECK_EXTRA_FATAL"),
                       d.expand("${STAGING_DATADIR_NATIVE}/cppcheck-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-cpplint.bbclass
+++ b/classes/sca-cpplint.bbclass
@@ -36,7 +36,7 @@ def do_sca_conv_cpplint(d):
     }
     pattern = r"^(?P<file>.*):(?P<line>\d+):\s+(?P<message>.*)\s+\[(?P<id>.*)\]\s+\[(?P<severity>\d)\]"
     _findings = []
-    _suppress = sca_suppress_init(d, "SCA_CPPLINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_CPPLINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/cpplint-${SCA_MODE}-suppress"))
 
     if os.path.exists(sca_raw_result_file(d, "cpplint")):
@@ -95,7 +95,7 @@ python do_sca_cpplint_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "cpplint", get_fatal_entries(d, "SCA_CPPLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "cpplint", get_fatal_entries(d, clean_split(d, "SCA_CPPLINT_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/cpplint-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-cvecheck.bbclass
+++ b/classes/sca-cvecheck.bbclass
@@ -38,7 +38,7 @@ def sca_create_data_file(d, patched, unpatched, cve_data):
     bb.utils.mkdirhier(os.path.dirname(cve_file))
 
     package_name = d.getVar("PN")
-    _suppress = sca_suppress_init(d, "", None, file_trace=False)
+    _suppress = sca_suppress_init(d, clean_split(d, ""), None, file_trace=False)
     items = []
     _findings = []
 

--- a/classes/sca-darglint.bbclass
+++ b/classes/sca-darglint.bbclass
@@ -27,7 +27,7 @@ def do_sca_conv_darglint(d):
 
     pattern = r"^(?P<file>.*?):(\w+):(?P<line>\d+):\s*(?P<severity>[A-Z]+)(?P<id>[0-9]+):\s*(?P<msg>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_DARGLINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_DARGLINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/darglint-${SCA_MODE}-suppress"))
     _findings = []
     if os.path.exists(sca_raw_result_file(d, "darglint")):
@@ -86,7 +86,7 @@ python do_sca_darglint_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "darglint", get_fatal_entries(d, "SCA_DARGLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "darglint", get_fatal_entries(d, clean_split(d, "SCA_DARGLINT_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/darglint-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-dennis.bbclass
+++ b/classes/sca-dennis.bbclass
@@ -32,7 +32,7 @@ def do_sca_conv_dennis(d):
         "W" : "warning",
     }
 
-    __suppress = sca_suppress_init(d, "SCA_DENNIS_EXTRA_SUPPRESS",
+    __suppress = sca_suppress_init(d, clean_split(d, "SCA_DENNIS_EXTRA_SUPPRESS"),
                                    d.expand("${STAGING_DATADIR_NATIVE}/dennis-${SCA_MODE}-suppress"),
                                    file_trace=False)
     _findings = []
@@ -82,8 +82,8 @@ python do_sca_dennis() {
             cmd_output = "E999: Parsing Error.\n1"
 
         if cmd_output:
-            prefix = "{}: ".format(f)
-            cmd_output = prefix + prefix.join(cmd_output.splitlines(True))
+            _prefix = "{}: ".format(f)
+            cmd_output = _prefix + _prefix.join(cmd_output.splitlines(True))
         allrun_output += cmd_output
 
     with open(sca_raw_result_file(d, "dennis"), "w") as o:
@@ -95,7 +95,7 @@ python do_sca_dennis() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "dennis", get_fatal_entries(d, "SCA_DENNIS_EXTRA_FATAL",
+    sca_task_aftermath(d, "dennis", get_fatal_entries(d, clean_split(d, "SCA_DENNIS_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/dennis-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-detectsecrets-core.bbclass
+++ b/classes/sca-detectsecrets-core.bbclass
@@ -27,7 +27,7 @@ def do_sca_conv_detectsecrets(d):
 
     items = []
     __excludes = sca_filter_files(d, d.getVar("SCA_SOURCES_DIR"), clean_split(d, "SCA_FILE_FILTER_EXTRA"))
-    __suppress = sca_suppress_init(d, "SCA_DETECTSECRETS_EXTRA_SUPPRESS",
+    __suppress = sca_suppress_init(d, clean_split(d, "SCA_DETECTSECRETS_EXTRA_SUPPRESS"),
                                     d.expand("${STAGING_DATADIR_NATIVE}/detectsecrets-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -70,7 +70,7 @@ python do_sca_detectsecrets_core() {
     import subprocess
     import json
 
-    _args = [d.getVar("PYTHON")]
+    _args = ["python3"]
     _args += [os.path.join(d.getVar("STAGING_BINDIR_NATIVE"), "detect-secrets")]
     _args += ["scan"]
     _args += ["--all-files"]
@@ -91,6 +91,6 @@ python do_sca_detectsecrets_core_report() {
     dm_output = do_sca_conv_detectsecrets(d)
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
-    sca_task_aftermath(d, "detectsecrets", get_fatal_entries(d, "SCA_DETECTSECRETS_EXTRA_FATAL",
+    sca_task_aftermath(d, "detectsecrets", get_fatal_entries(d, clean_split(d, "SCA_DETECTSECRETS_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/detectsecrets-${SCA_MODE}-fatal")))
 }

--- a/classes/sca-file-filter.bbclass
+++ b/classes/sca-file-filter.bbclass
@@ -6,6 +6,7 @@ inherit sca-license-filter
 ## Global file filter
 SCA_FILE_FILTER ?= "\
                     .pc/* \
+                    .git/* \
                     tests/* \
                     test/* \
                     doc/* \

--- a/classes/sca-flake8-core.bbclass
+++ b/classes/sca-flake8-core.bbclass
@@ -52,7 +52,7 @@ def do_sca_conv_flake8(d):
         "W": "warning",
     }
     _findings = []
-    _suppress = sca_suppress_init(d, "SCA_FLAKE8_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_FLAKE8_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/flake8-${SCA_MODE}-suppress"))
 
     if os.path.exists(sca_raw_result_file(d, "flake8")):
@@ -110,7 +110,7 @@ python do_sca_flake8_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "flake8", get_fatal_entries(d, "SCA_FLAKE8_EXTRA_FATAL",
+    sca_task_aftermath(d, "flake8", get_fatal_entries(d, clean_split(d, "SCA_FLAKE8_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/flake8-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-flawfinder.bbclass
+++ b/classes/sca-flawfinder.bbclass
@@ -37,7 +37,7 @@ def do_sca_conv_flawfinder(d):
         "1" : "info"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_FLAWFINDER_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_FLAWFINDER_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/flawfinder-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -93,7 +93,7 @@ python do_sca_flawfinder_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "flawfinder", get_fatal_entries(d, "SCA_FLAWFINDER_EXTRA_FATAL",
+    sca_task_aftermath(d, "flawfinder", get_fatal_entries(d, clean_split(d, "SCA_FLAWFINDER_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/flawfinder-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-flint.bbclass
+++ b/classes/sca-flint.bbclass
@@ -35,7 +35,7 @@ def do_sca_conv_flint(d):
         "Advice" : "info"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_FLINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_FLINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/flint-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -95,7 +95,7 @@ python do_sca_flint_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "flint", get_fatal_entries(d, "SCA_FLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "flint", get_fatal_entries(d, clean_split(d, "SCA_FLINT_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/flint-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-gcc.bbclass
+++ b/classes/sca-gcc.bbclass
@@ -40,7 +40,7 @@ def sca_gcc_hardening(d):
     _cflags = [x for x in d.getVar("CFLAGS").split(" ") if x] + [x for x in d.getVar("CXXFLAGS").split(" ") if x]
     _cxxflags = [x for x in d.getVar("CXXFLAGS").split(" ") if x] + [x for x in d.getVar("CPPFLAGS").split(" ") if x]
 
-    _suppress = sca_suppress_init(d, "SCA_GCC_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_GCC_EXTRA_SUPPRESS"),
                                     d.expand("${STAGING_DATADIR_NATIVE}/gcc-${SCA_MODE}-suppress"))
     _excludes = sca_filter_files(d, d.getVar("SCA_SOURCES_DIR"), clean_split(d, "SCA_FILE_FILTER_EXTRA"))
 
@@ -228,7 +228,7 @@ def do_sca_conv_gcc(d):
         "note": "info"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_GCC_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_GCC_EXTRA_SUPPRESS"),
                                     d.expand("${STAGING_DATADIR_NATIVE}/gcc-${SCA_MODE}-suppress"))
     _excludes = sca_filter_files(d, d.getVar("SCA_SOURCES_DIR"), clean_split(d, "SCA_FILE_FILTER_EXTRA"))
     _findings = []
@@ -281,7 +281,7 @@ python do_sca_gcc_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "gcc", get_fatal_entries(d, "SCA_GCC_EXTRA_FATAL",
+    sca_task_aftermath(d, "gcc", get_fatal_entries(d, clean_split(d, "SCA_GCC_EXTRA_FATAL"),
                          d.expand("${STAGING_DATADIR_NATIVE}/gcc-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-global.bbclass
+++ b/classes/sca-global.bbclass
@@ -163,6 +163,7 @@ SCA_HASHEXCLUDE_VARS = "\
                         __SCA_DATAMODEL_STORAGE \
                         SCA_DATAMODEL_STORAGE \
                         SCA_LAYERDIR \
+                        SCA_SDKGEN_TASKS \
                         "
 
 # some global vardepexcludes

--- a/classes/sca-golicensecheck.bbclass
+++ b/classes/sca-golicensecheck.bbclass
@@ -31,7 +31,7 @@ def do_sca_conv_golicensecheck(d):
     items = []
     pattern = r"^(?P<pkg>.*):\[(?P<id>.+)\]\s+(?P<msg>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_GOLICENSECHECK_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_GOLICENSECHECK_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/golicensecheck-${SCA_MODE}-suppress"),
                                   file_trace=False)
     _findings = []
@@ -128,12 +128,14 @@ python do_sca_golicensecheck_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "golicensecheck", get_fatal_entries(d, "SCA_GOLICENSECHECK_EXTRA_FATAL",
+    sca_task_aftermath(d, "golicensecheck", get_fatal_entries(d, clean_split(d, "SCA_GOLICENSECHECK_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/golicensecheck-${SCA_MODE}-fatal")))
 }
 
 do_sca_golicensecheck[doc] = "Scan license information in workspace"
 do_sca_golicensecheck_report[doc] = "Report findings of do_sca_golicensecheck"
+do_sca_golicensecheck[nosdkgen] = "1"
+do_sca_golicensecheck_report[nosdkgen] = "1"
 addtask do_sca_golicensecheck after do_compile before do_sca_tracefiles
 addtask do_sca_golicensecheck_report after do_sca_tracefiles before do_sca_deploy
 

--- a/classes/sca-golint.bbclass
+++ b/classes/sca-golint.bbclass
@@ -29,7 +29,7 @@ def do_sca_conv_golint(d):
     items = []
     pattern = r"^(?P<file>.*):(?P<line>\d+):(?P<col>\d+):\s*(?P<msg>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_GOLINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_GOLINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/golint-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -85,7 +85,7 @@ python do_sca_golint_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "golint", get_fatal_entries(d, "SCA_GOLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "golint", get_fatal_entries(d, clean_split(d, "SCA_GOLINT_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/golint-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-helper.bbclass
+++ b/classes/sca-helper.bbclass
@@ -337,7 +337,7 @@ SCA_SOURCECHECKSUM ?= "${T}/sca_seen_sources.txt"
 
 do_sca_get_sources() {
     echo "" > ${SCA_SOURCECHECKSUM}
-    find ${S} -type f -exec sh -c "md5sum '{}' 2>/dev/null || true" >> ${SCA_SOURCECHECKSUM} \;
+    find ${S} -type f  -exec sh -c "md5sum '{}' 2>/dev/null || true" >> ${SCA_SOURCECHECKSUM} \; || true
 }
 
 do_sca_get_sources[doc] = "Get all source files of the workspace"

--- a/classes/sca-helper.bbclass
+++ b/classes/sca-helper.bbclass
@@ -75,7 +75,7 @@ def _combine_x_entries(d, input_file, extra_key):
         _rules_file = _filename
         with open(_rules_file) as f:
             res = [x.strip(" \n") for x in f.readlines() if x.strip(" \n")]
-    res += clean_split(d, extra_key)
+    res += extra_key
     return res
 
 
@@ -337,7 +337,7 @@ SCA_SOURCECHECKSUM ?= "${T}/sca_seen_sources.txt"
 
 do_sca_get_sources() {
     echo "" > ${SCA_SOURCECHECKSUM}
-    find ${S} -type f -exec sh -c "md5sum {} 2>/dev/null || true" >> ${SCA_SOURCECHECKSUM} \;
+    find ${S} -type f -exec sh -c "md5sum '{}' 2>/dev/null || true" >> ${SCA_SOURCECHECKSUM} \;
 }
 
 do_sca_get_sources[doc] = "Get all source files of the workspace"

--- a/classes/sca-it.bbclass
+++ b/classes/sca-it.bbclass
@@ -26,7 +26,7 @@ def do_sca_conv_it(d):
 
     pattern = r"^\s+-\s+(?P<file>.*):(?P<line>\d+):(?P<col>\d+)\s+=>\s+(?P<id>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_IT_EXTRA_SUPPRESS", 
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_IT_EXTRA_SUPPRESS"), 
                                   d.expand("${STAGING_DATADIR_NATIVE}/it-${SCA_MODE}-suppress"))
     _excludes = sca_filter_files(d, d.getVar("SCA_SOURCES_DIR"), clean_split(d, "SCA_FILE_FILTER_EXTRA"))
 
@@ -83,7 +83,7 @@ python do_sca_it_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "it", get_fatal_entries(d, "SCA_IT_EXTRA_FATAL",
+    sca_task_aftermath(d, "it", get_fatal_entries(d, clean_split(d, "SCA_IT_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/it-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-jsonlint-core.bbclass
+++ b/classes/sca-jsonlint-core.bbclass
@@ -31,7 +31,7 @@ def do_sca_conv_jsonlint(d):
         "warning" : "warning",
         "info": "info"
     }
-    _suppress = sca_suppress_init(d, "", None)
+    _suppress = sca_suppress_init(d, clean_split(d, ""), None)
     _findings = []
 
     if os.path.exists(sca_raw_result_file(d, "jsonlint")):
@@ -82,7 +82,7 @@ python do_sca_jsonlint_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "jsonlint", get_fatal_entries(d, "SCA_JSONLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "jsonlint", get_fatal_entries(d, clean_split(d, "SCA_JSONLINT_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/jsonlint-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-kconfighard-recipe.bbclass
+++ b/classes/sca-kconfighard-recipe.bbclass
@@ -37,7 +37,7 @@ def do_sca_conv_kconfighard(d):
         "lockdown" : "warning"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_KCONFIGHARD_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_KCONFIGHARD_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/kconfighard-${SCA_MODE}-suppress"),
                                   file_trace=False)
     _findings = []
@@ -106,7 +106,7 @@ python do_sca_kconfighard() {
         with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
             o.write(dm_output)
 
-        sca_task_aftermath(d, "kconfighard", get_fatal_entries(d, "SCA_KCONFIGHARD_EXTRA_FATAL",
+        sca_task_aftermath(d, "kconfighard", get_fatal_entries(d, clean_split(d, "SCA_KCONFIGHARD_EXTRA_FATAL"),
                             d.expand("${STAGING_DATADIR_NATIVE}/kconfighard-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-license-image-helper.bbclass
+++ b/classes/sca-license-image-helper.bbclass
@@ -14,3 +14,4 @@ python do_sca_image_pkg_list() {
     with open(d.getVar("SCA_IMAGE_PKG_LIST"), "w") as o:
         json.dump(image_list_installed_packages(d), o)
 }
+do_sca_image_pkg_list[nosdkgen] = "1"

--- a/classes/sca-licensecheck.bbclass
+++ b/classes/sca-licensecheck.bbclass
@@ -29,7 +29,7 @@ def do_sca_conv_licensecheck(d):
     items = []
     pattern = r"^(?P<pkg>.*):\[(?P<id>.+)\]\s+(?P<msg>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_LICENSECHECK_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_LICENSECHECK_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/licensecheck-${SCA_MODE}-suppress"),
                                   file_trace=False)
     _findings = []
@@ -117,7 +117,7 @@ python do_sca_licensecheck_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "licensecheck", get_fatal_entries(d, "SCA_LICENSECHECK_EXTRA_FATAL",
+    sca_task_aftermath(d, "licensecheck", get_fatal_entries(d, clean_split(d, "SCA_LICENSECHECK_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/licensecheck-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-looong.bbclass
+++ b/classes/sca-looong.bbclass
@@ -27,7 +27,7 @@ def do_sca_conv_looong(d):
 
     pattern = r"^(?P<func>.*?)\s+\[(?P<file>.*)\]\s+\[.*\]\s+(?P<level>\d+)"
 
-    _suppress = sca_suppress_init(d, "", None)
+    _suppress = sca_suppress_init(d, clean_split(d, ""), None)
     _excludes = sca_filter_files(d, d.getVar("SCA_SOURCES_DIR"), clean_split(d, "SCA_FILE_FILTER_EXTRA"))
 
     _findings = []
@@ -68,7 +68,7 @@ python do_sca_looong() {
     import subprocess
     import re
 
-    _args = ["python3", os.path.join(d.getVar("STAGING_DIR_NATIVE"), d.getVar("PYTHON_SITEPACKAGES_DIR")[1:], "looong", "main.py")]
+    _args = ["looong"]
     _args += ["-d", d.getVar("SCA_SOURCES_DIR")]
 
     _files = get_files_by_extention_or_shebang(d, d.getVar("SCA_SOURCES_DIR"), d.getVar("SCA_PYTHON_SHEBANG"), ".py",
@@ -93,7 +93,7 @@ python do_sca_looong_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "looong", get_fatal_entries(d, "SCA_LOOONG_EXTRA_FATAL",
+    sca_task_aftermath(d, "looong", get_fatal_entries(d, clean_split(d, "SCA_LOOONG_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/looong-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-lse-image.bbclass
+++ b/classes/sca-lse-image.bbclass
@@ -33,7 +33,7 @@ def do_sca_conv_lse(d):
 
     pattern = r"^\[(?P<sev>.)\]\s+(?P<id>[a-z0-9]+)\s+(?P<msg>.*?)\.+\s+yes!"
 
-    _suppress = sca_suppress_init(d, "SCA_LSE_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_LSE_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/lse-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -80,9 +80,10 @@ fakeroot python do_sca_lse() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "lse", get_fatal_entries(d, "SCA_LSE_EXTRA_FATAL",
+    sca_task_aftermath(d, "lse", get_fatal_entries(d, clean_split(d, "SCA_LSE_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/lse-${SCA_MODE}-fatal")))
 }
 
 do_sca_lse[doc] = "Find security weaknesses in a image"
+do_sca_lse[nosdkgen] = "1"
 addtask do_sca_lse before do_sca_deploy after do_image

--- a/classes/sca-lynis-image.bbclass
+++ b/classes/sca-lynis-image.bbclass
@@ -31,7 +31,7 @@ def do_sca_conv_lynis(d):
         "*" : "warning"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_LYNIS_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_LYNIS_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/lynis-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -82,11 +82,12 @@ fakeroot python do_sca_lynis() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "lynis", get_fatal_entries(d, "SCA_LYNIS_EXTRA_FATAL",
+    sca_task_aftermath(d, "lynis", get_fatal_entries(d, clean_split(d, "SCA_LYNIS_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/lynis-${SCA_MODE}-fatal")))
 }
 
 do_sca_lynis[doc] = "Audit image with lynis"
+do_sca_lynis[nosdkgen] = "1"
 addtask do_sca_lynis before do_sca_deploy after do_image
 
 DEPENDS += "sca-image-lynis-rules-native"

--- a/classes/sca-msgcheck.bbclass
+++ b/classes/sca-msgcheck.bbclass
@@ -28,7 +28,7 @@ def do_sca_conv_msgcheck(d):
     items = []
     pattern = r"^(?P<file>.*):(?P<line>\d+):(\s+(?P<severity>warning|error):\s|\s+\[(?P<id>.*)\]\s+|\s+)(?P<msg>.*)"
 
-    __suppress = sca_suppress_init(d, "SCA_MSGCHECK_EXTRA_SUPPRESS",
+    __suppress = sca_suppress_init(d, clean_split(d, "SCA_MSGCHECK_EXTRA_SUPPRESS"),
                                    d.expand("${STAGING_DATADIR_NATIVE}/msgcheck-${SCA_MODE}-suppress"),
                                    file_trace=False)
     _findings = []
@@ -88,7 +88,7 @@ python do_sca_msgcheck() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "msgcheck", get_fatal_entries(d, "SCA_MSGCHECK_EXTRA_FATAL",
+    sca_task_aftermath(d, "msgcheck", get_fatal_entries(d, clean_split(d, "SCA_MSGCHECK_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/msgcheck-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-multimetric-core.bbclass
+++ b/classes/sca-multimetric-core.bbclass
@@ -57,7 +57,7 @@ def do_sca_conv_multimetric(d):
     package_name = d.getVar("PN")
     buildpath = d.getVar("SCA_SOURCES_DIR")
 
-    _suppress = sca_suppress_init(d, "SCA_MULTIMETRIC_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_MULTIMETRIC_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/multimetric-${SCA_MODE}-suppress"))
     _findings = []
     if os.path.exists(sca_raw_result_file(d, "multimetric")):
@@ -233,7 +233,7 @@ python do_sca_multimetric_core_report() {
     dm_output = do_sca_conv_multimetric(d)
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
-    sca_task_aftermath(d, "multimetric", get_fatal_entries(d, "SCA_MULTIMETRIC_EXTRA_FATAL",
+    sca_task_aftermath(d, "multimetric", get_fatal_entries(d, clean_split(d, "SCA_MULTIMETRIC_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/multimetric-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-multimetric-image.bbclass
+++ b/classes/sca-multimetric-image.bbclass
@@ -71,6 +71,8 @@ python do_sca_multimetric_image() {
 
 do_sca_multimetric_image[doc] = "Get code metrics for image"
 do_sca_deploy_multimetric_image[doc] = "Deploy results of do_sca_multimetric_core"
+do_sca_multimetric_image[nosdkgen] = "1"
+do_sca_deploy_multimetric_image[nosdkgen] = "1"
 addtask do_sca_multimetric_core before do_image_complete after do_image
 addtask do_sca_multimetric_core_report after do_sca_multimetric_core before do_sca_deploy
 

--- a/classes/sca-mypy-core.bbclass
+++ b/classes/sca-mypy-core.bbclass
@@ -28,7 +28,7 @@ def do_sca_conv_mypy(d):
     }
 
     _findings = []
-    _suppress = sca_suppress_init(d, "SCA_MYPY_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_MYPY_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/mypy-${SCA_MODE}-suppress"))
 
     if os.path.exists(sca_raw_result_file(d, "mypy")):
@@ -63,7 +63,7 @@ python do_sca_mypy_core() {
     import subprocess
 
     os.environ["MYPY_CACHE_DIR"] = os.path.join(d.getVar("T"), "mypy_cache")
-    _args = [os.path.join(d.getVar("STAGING_BINDIR_NATIVE"), "python3-native/python3"), "-m", "mypy"]
+    _args = ["python3", "-m", "mypy"]
     _args += ["--strict"]
     _args += ["--no-incremental"]
     _args += ["--python-version", d.getVar("PYTHON_BASEVERSION")]
@@ -86,7 +86,7 @@ python do_sca_mypy_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "mypy", get_fatal_entries(d, "SCA_MYPY_EXTRA_FATAL",
+    sca_task_aftermath(d, "mypy", get_fatal_entries(d, clean_split(d, "SCA_MYPY_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/mypy-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-oelint-core.bbclass
+++ b/classes/sca-oelint-core.bbclass
@@ -42,7 +42,7 @@ def do_sca_conv_oelint(d, _files):
         "info": "info"
     }
     _findings = []
-    _suppress = sca_suppress_init(d, "SCA_OELINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_OELINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/oelint-${SCA_MODE}-suppress"),
                                   file_trace=False)
     _spared_layer_files = _files
@@ -127,6 +127,6 @@ python do_sca_oelint_core() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "oelint", get_fatal_entries(d, "SCA_OELINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "oelint", get_fatal_entries(d, clean_split(d, "SCA_OELINT_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/oelint-${SCA_MODE}-fatal")))
 }

--- a/classes/sca-oelint-image.bbclass
+++ b/classes/sca-oelint-image.bbclass
@@ -7,6 +7,7 @@ inherit sca-oelint-core
 inherit sca-conv-to-export
 
 do_sca_oelint_core[doc] = "Lint bitbake recipes"
+do_sca_oelint_core[nosdkgen] = "1"
 addtask do_sca_oelint_core before do_sca_deploy after do_image
 
 DEPENDS += "sca-image-oelint-rules-native"

--- a/classes/sca-oelint-recipe.bbclass
+++ b/classes/sca-oelint-recipe.bbclass
@@ -7,6 +7,7 @@ inherit sca-oelint-core
 inherit sca-conv-to-export
 
 do_sca_oelint_core[doc] = "Lint bitbake recipes"
+do_sca_oelint_core[nosdkgen] = "1"
 addtask do_sca_oelint_core before do_sca_deploy after do_compile
 
 DEPENDS += "sca-recipe-oelint-rules-native"

--- a/classes/sca-perl.bbclass
+++ b/classes/sca-perl.bbclass
@@ -29,7 +29,7 @@ def do_sca_conv_perl(d):
     items = []
     pattern = r"^(?P<msg>.*)\s+at\s+(?P<file>.*)\s+line\s+(?P<line>\d+)"
 
-    _suppress = sca_suppress_init(d, "SCA_PERL_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_PERL_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/perl-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -90,7 +90,7 @@ python do_sca_perl_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "perl", get_fatal_entries(d, "SCA_PERL_EXTRA_FATAL",
+    sca_task_aftermath(d, "perl", get_fatal_entries(d, clean_split(d, "SCA_PERL_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/perl-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-perlcritic.bbclass
+++ b/classes/sca-perlcritic.bbclass
@@ -37,7 +37,7 @@ def do_sca_conv_perlcritic(d):
         "1": "info"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_PERLCRITIC_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_PERLCRITIC_EXTRA_SUPPRESS"),
                                    d.expand("${STAGING_DATADIR_NATIVE}/perlcritic-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -98,7 +98,7 @@ python do_sca_perlcritic_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "perlcritic", get_fatal_entries(d, "SCA_PERLCRITIC_EXTRA_FATAL",
+    sca_task_aftermath(d, "perlcritic", get_fatal_entries(d, clean_split(d, "SCA_PERLCRITIC_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/perlcritic-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-pkgqaenc-pyident.bbclass
+++ b/classes/sca-pkgqaenc-pyident.bbclass
@@ -121,7 +121,10 @@ def do_sca_pkgqaenc_pythonident(d, package):
 
         # Try to map against known errata
         if _imp in builtins:
-            third_party_packages.add("python3-core")
+            if bb.data.inherits_class('nativesdk', d):
+                third_party_packages.add("nativesdk-python3-core")
+            else:
+                third_party_packages.add("python3-core")
         else:
             for needle in _needles:
                 _self_served = do_sca_pkgqaenc_is_provided_by_self(d, needle[0], package, isexec=False, suffix=needle[1])

--- a/classes/sca-pkgqaenc.bbclass
+++ b/classes/sca-pkgqaenc.bbclass
@@ -90,7 +90,7 @@ def do_sca_conv_pkgqaenc(d):
     items = []
     pattern = r"^WARNING:\s+\[(?P<id>.*?)\]:\s+(?P<path>.*?):\s+(?P<msg>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_PKGQAENC_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_PKGQAENC_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/pkgqaenc-${SCA_MODE}-suppress"),
                                   file_trace=False)
     _findings = []
@@ -189,13 +189,14 @@ python do_sca_pkgqaenc() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "pkgqaenc", get_fatal_entries(d, "SCA_PKGQAENC_EXTRA_FATAL",
+    sca_task_aftermath(d, "pkgqaenc", get_fatal_entries(d, clean_split(d, "SCA_PKGQAENC_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/pkgqaenc-${SCA_MODE}-fatal")))
 }
 
 
 do_sca_pkgqaenc[doc] = "Lint produced packages"
 do_sca_pkgqaenc[depends] += "python3-native:do_populate_sysroot ${PN}:do_prepare_recipe_sysroot"
+do_sca_pkgqaenc[nosdkgen] = "1"
 addtask do_sca_pkgqaenc before do_sca_deploy after do_package
 
-DEPENDS += "pkgqaenc-native sca-recipe-pkgqaenc-rules-native python3-native"
+DEPENDS += "pkgqaenc-native sca-recipe-pkgqaenc-rules-native python3-native file-native"

--- a/classes/sca-protolint.bbclass
+++ b/classes/sca-protolint.bbclass
@@ -26,7 +26,7 @@ def do_sca_conv_protolint(d):
     buildpath = d.getVar("SCA_SOURCES_DIR")
 
     items = []
-    _suppress = sca_suppress_init(d, "SCA_PROTOLINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_PROTOLINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/protolint-${SCA_MODE}-suppress"),
                                   file_trace=False)
     _findings = []
@@ -119,7 +119,7 @@ python do_sca_protolint_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "protolint", get_fatal_entries(d, "SCA_PROTOLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "protolint", get_fatal_entries(d, clean_split(d, "SCA_PROTOLINT_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/protolint-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-pscan.bbclass
+++ b/classes/sca-pscan.bbclass
@@ -33,7 +33,7 @@ def do_sca_conv_pscan(d):
         "Warning" : "warning"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_PSCAN_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_PSCAN_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/pscan-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -90,7 +90,7 @@ python do_sca_pscan_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "pscan", get_fatal_entries(d, "SCA_PSCAN_EXTRA_FATAL",
+    sca_task_aftermath(d, "pscan", get_fatal_entries(d, clean_split(d, "SCA_PSCAN_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/pscan-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-pyfindinjection-core.bbclass
+++ b/classes/sca-pyfindinjection-core.bbclass
@@ -32,7 +32,7 @@ def do_sca_conv_pyfindinjection(d):
         "eval() is just generally evil" : ("error", "evil.eval"),
     }
 
-    _suppress = sca_suppress_init(d, "SCA_PYFINDINJECTION_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_PYFINDINJECTION_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/pyfindinjection-${SCA_MODE}-suppress"))
     _excludes = sca_filter_files(d, d.getVar("SCA_SOURCES_DIR"), clean_split(d, "SCA_FILE_FILTER_EXTRA"))
     _findings = []
@@ -69,7 +69,7 @@ python do_sca_pyfindinjection_core() {
     import os
     import subprocess
 
-    _args = [os.path.join(d.getVar("STAGING_BINDIR_NATIVE"), "python3-native", "python3")]
+    _args = ["python3"]
     _args += [os.path.join(d.getVar("STAGING_BINDIR_NATIVE"), "py-find-injection")]
 
     _files = get_files_by_extention_or_shebang(d, d.getVar("SCA_SOURCES_DIR"), d.getVar("SCA_PYTHON_SHEBANG"), ".py",
@@ -90,7 +90,7 @@ python do_sca_pyfindinjection_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "pyfindinjection", get_fatal_entries(d, "SCA_PYFINDINJECTION_EXTRA_FATAL",
+    sca_task_aftermath(d, "pyfindinjection", get_fatal_entries(d, clean_split(d, "SCA_PYFINDINJECTION_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/pyfindinjection-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-pylint-core.bbclass
+++ b/classes/sca-pylint-core.bbclass
@@ -28,7 +28,7 @@ def do_sca_conv_pylint(d):
     }
 
     _findings = []
-    _suppress = sca_suppress_init(d, "SCA_PYLINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_PYLINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/pylint-${SCA_MODE}-suppress"))
 
     if os.path.exists(sca_raw_result_file(d, "pylint")):
@@ -100,7 +100,7 @@ python do_sca_pylint_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "pylint", get_fatal_entries(d, "SCA_PYLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "pylint", get_fatal_entries(d, clean_split(d, "SCA_PYLINT_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/pylint-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-pylint-recipe.bbclass
+++ b/classes/sca-pylint-recipe.bbclass
@@ -21,6 +21,6 @@ SCA_PYLINT_LIBATH ?= "${STAGING_LIBDIR}/python${PYTHON_BASEVERSION}/:${STAGING_L
 do_sca_pylint_core[doc] = "Lint python code with pylint"
 do_sca_pylint_core_report[doc] = "Report findings from do_sca_pylint_core"
 addtask do_sca_pylint_core after do_compile before do_sca_tracefiles
-addtask do_sca_pylint_core_report after do_sca_tracefiles before do_sca_deploy
+addtask do_sca_pylint_core_report after do_sca_pylint_core do_sca_tracefiles before do_sca_deploy
 
 DEPENDS += "sca-recipe-pylint-rules-native"

--- a/classes/sca-pysymcheck.bbclass
+++ b/classes/sca-pysymcheck.bbclass
@@ -33,7 +33,7 @@ def do_sca_conv_pysymcheck(d):
         "info": "info"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_PYSYMCHECK_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_PYSYMCHECK_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/pysymcheck-${SCA_MODE}-suppress"),
                                   file_trace=False)
 
@@ -87,7 +87,7 @@ python do_sca_pysymcheck() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "pysymcheck", get_fatal_entries(d, "SCA_PYSYMCHECK_EXTRA_FATAL",
+    sca_task_aftermath(d, "pysymcheck", get_fatal_entries(d, clean_split(d, "SCA_PYSYMCHECK_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/pysymcheck-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-rats.bbclass
+++ b/classes/sca-rats.bbclass
@@ -33,7 +33,7 @@ def do_sca_conv_rats(d):
         "Default": "info"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_RATS_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_RATS_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/rats-${SCA_MODE}-suppress"))
 
     _findings = []
@@ -136,7 +136,7 @@ python do_sca_rats_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "rats", get_fatal_entries(d, "SCA_RATS_EXTRA_FATAL",
+    sca_task_aftermath(d, "rats", get_fatal_entries(d, clean_split(d, "SCA_RATS_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/rats-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-reconbf-image.bbclass
+++ b/classes/sca-reconbf-image.bbclass
@@ -29,7 +29,7 @@ def do_sca_conv_reconbf(d):
     items = []
 
     __excludes = sca_filter_files(d, d.getVar("SCA_SOURCES_DIR"), clean_split(d, "SCA_FILE_FILTER_EXTRA"))
-    _suppress = sca_suppress_init(d, "SCA_RECONBF_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_RECONBF_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/reconbf-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -93,11 +93,12 @@ fakeroot python do_sca_reconbf() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "reconbf", get_fatal_entries(d, "SCA_RECONBF_EXTRA_FATAL",
+    sca_task_aftermath(d, "reconbf", get_fatal_entries(d, clean_split(d, "SCA_RECONBF_EXTRA_FATAL"),
                         d.expand("${STAGING_DATADIR_NATIVE}/reconbf-${SCA_MODE}-fatal")))
 }
 
 do_sca_reconbf[doc] = "Run reconbf audit on image"
+do_sca_reconbf[nosdkgen] = "1"
 addtask do_sca_reconbf before do_sca_deploy after do_image
 
 DEPENDS += "sca-image-reconbf-rules-native"

--- a/classes/sca-reuse.bbclass
+++ b/classes/sca-reuse.bbclass
@@ -29,7 +29,7 @@ def do_sca_conv_reuse(d):
     items = []
     pattern = r"^(?P<pkg>.*):\[(?P<id>.+)\]\s+(?P<msg>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_REUSE_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_REUSE_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/reuse-${SCA_MODE}-suppress"),
                                   file_trace=False)
     _findings = []
@@ -113,12 +113,14 @@ python do_sca_reuse_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "reuse", get_fatal_entries(d, "SCA_REUSE_EXTRA_FATAL",
+    sca_task_aftermath(d, "reuse", get_fatal_entries(d, clean_split(d, "SCA_REUSE_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/reuse-${SCA_MODE}-fatal")))
 }
 
 do_sca_reuse[doc] = "License compliance with reuse"
 do_sca_reuse_report[doc] = "Report findings of do_sca_reuse"
+do_sca_reuse[nosdkgen] = "1"
+do_sca_reuse_report[nosdkgen] = "1"
 addtask do_sca_reuse after do_compile before do_sca_tracefiles
 addtask do_sca_reuse_report after do_sca_tracefiles before do_sca_deploy
 

--- a/classes/sca-revive.bbclass
+++ b/classes/sca-revive.bbclass
@@ -28,7 +28,7 @@ def do_sca_conv_revive(d):
     items = []
     pattern = r"^(?P<file>.*):(?P<line>\d+):(?P<col>\d+):\s+\[(?P<id>\w+)\]\s+(?P<msg>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_REVIVE_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_REVIVE_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/revive-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -83,7 +83,7 @@ python do_sca_revive_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "revive", get_fatal_entries(d, "SCA_REVIVE_EXTRA_FATAL",
+    sca_task_aftermath(d, "revive", get_fatal_entries(d, clean_split(d, "SCA_REVIVE_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/revive-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-scancode.bbclass
+++ b/classes/sca-scancode.bbclass
@@ -44,7 +44,7 @@ def do_sca_conv_scancode(d):
     items = []
     pattern = r"^(?P<pkg>.*):\[(?P<id>.+)\]\s+(?P<msg>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_SCANCODE_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_SCANCODE_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/scancode-${SCA_MODE}-suppress"),
                                   file_trace=False)
     _findings = []
@@ -139,12 +139,14 @@ python do_sca_scancode_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "scancode", get_fatal_entries(d, "SCA_SCANCODE_EXTRA_FATAL",
+    sca_task_aftermath(d, "scancode", get_fatal_entries(d, clean_split(d, "SCA_SCANCODE_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/scancode-${SCA_MODE}-fatal")))
 }
 
 do_sca_scancode[doc] = "License compliance with scancode"
 do_sca_scancode_report[doc] = "Report findings of do_sca_scancode"
+do_sca_scancode[nosdkgen] = "1"
+do_sca_scancode_report[nosdkgen] = "1"
 addtask do_sca_scancode after do_compile before do_sca_tracefiles
 addtask do_sca_scancode_report after do_sca_tracefiles before do_sca_deploy
 

--- a/classes/sca-setuptoolslint.bbclass
+++ b/classes/sca-setuptoolslint.bbclass
@@ -30,7 +30,7 @@ def do_sca_conv_setuptoolslint(d, cmd_output=""):
 
     pattern = r"^(?P<file>.*):error:\s+(?P<msg>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_SETUPTOOLSLINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_SETUPTOOLSLINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/setuptoolslint-${SCA_MODE}-suppress"),
                                   file_trace=False)
     _findings = []
@@ -96,7 +96,7 @@ python do_sca_setuptoolslint() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "setuptoolslint", get_fatal_entries(d, "SCA_SETUPTOOLSLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "setuptoolslint", get_fatal_entries(d, clean_split(d, "SCA_SETUPTOOLSLINT_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/setuptoolslint-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-shellcheck-core.bbclass
+++ b/classes/sca-shellcheck-core.bbclass
@@ -18,7 +18,7 @@ def do_sca_conv_shellcheck(d):
 
     package_name = d.getVar("PN")
     buildpath = d.getVar("SCA_SOURCES_DIR")
-    _suppress = sca_suppress_init(d, "SCA_SHELLCHECK_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_SHELLCHECK_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/shellcheck-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -89,7 +89,7 @@ python do_sca_shellcheck_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "shellcheck", get_fatal_entries(d, "SCA_SHELLCHECK_EXTRA_FATAL",
+    sca_task_aftermath(d, "shellcheck", get_fatal_entries(d, clean_split(d, "SCA_SHELLCHECK_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/shellcheck-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-slick-core.bbclass
+++ b/classes/sca-slick-core.bbclass
@@ -27,7 +27,7 @@ def do_sca_conv_slick(d):
     pattern = r"^(\d+|/|\s|:)*\s+(?P<file>.*):(?P<line>\d+):(?P<col>\d+):\s+(?P<msg>.*)"
 
     _findings = []
-    _suppress = sca_suppress_init(d, "SCA_SLICK_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_SLICK_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/slick-${SCA_MODE}-suppress"))
 
     if os.path.exists(sca_raw_result_file(d, "slick")):
@@ -78,7 +78,7 @@ python do_sca_slick_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "slick", get_fatal_entries(d, "SCA_SLICK_EXTRA_FATAL",
+    sca_task_aftermath(d, "slick", get_fatal_entries(d, clean_split(d, "SCA_SLICK_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/slick-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-sparse.bbclass
+++ b/classes/sca-sparse.bbclass
@@ -39,7 +39,7 @@ def do_sca_conv_sparse(d):
         "info" : "info"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_SPARSE_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_SPARSE_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/sparse-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -102,7 +102,7 @@ python do_sca_sparse_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "sparse", get_fatal_entries(d, "SCA_SPARSE_EXTRA_FATAL",
+    sca_task_aftermath(d, "sparse", get_fatal_entries(d, clean_split(d, "SCA_SPARSE_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/sparse-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-stank-core.bbclass
+++ b/classes/sca-stank-core.bbclass
@@ -22,7 +22,7 @@ def do_sca_conv_stank(d):
 
     package_name = d.getVar("PN")
     buildpath = d.getVar("SCA_SOURCES_DIR")
-    _suppress = sca_suppress_init(d, "SCA_STANK_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_STANK_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/stank-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -102,7 +102,7 @@ python do_sca_stank_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "stank", get_fatal_entries(d, "SCA_STANK_EXTRA_FATAL",
+    sca_task_aftermath(d, "stank", get_fatal_entries(d, clean_split(d, "SCA_STANK_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/stank-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-sudokiller-image.bbclass
+++ b/classes/sca-sudokiller-image.bbclass
@@ -29,7 +29,7 @@ def do_sca_conv_sudokiller(d):
     pattern = r"^\[\-]\s+(?P<msg>.*)(\:+|\s+)"
     cve_pattern = r"^\[\+\]\s+Please\s+find the following exploit for (?P<msg>[A-Z\-0-9]+) in the exploits' directory"
 
-    _suppress = sca_suppress_init(d, "SCA_SUDOKILLER_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_SUDOKILLER_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/sudokiller-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -98,11 +98,12 @@ fakeroot python do_sca_sudokiller() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "sudokiller", get_fatal_entries(d, "SCA_SUDOKILLER_EXTRA_FATAL",
+    sca_task_aftermath(d, "sudokiller", get_fatal_entries(d, clean_split(d, "SCA_SUDOKILLER_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/sudokiller-${SCA_MODE}-fatal")))
 }
 
 do_sca_sudokiller[doc] = "Find exploitable CVEs of sudo in image"
+do_sca_sudokiller[nosdkgen] = "1"
 addtask do_sca_sudokiller before do_sca_deploy after do_image
 
 DEPENDS += "sca-image-sudokiller-rules-native"

--- a/classes/sca-suppress.bbclass
+++ b/classes/sca-suppress.bbclass
@@ -1,10 +1,12 @@
 inherit sca-helper
 
+SCA_NO_TRACEFILES ?= ""
+
 def sca_suppress_init(d, suppress_extra, suppress_file, file_trace=True):
     import os
     import sys
     import re
-    import urllib
+    from urllib import parse
     import bb
     import json
 
@@ -23,7 +25,7 @@ def sca_suppress_init(d, suppress_extra, suppress_file, file_trace=True):
                 self.File = ".*"
 
         def __unquote(self, value):
-            return urllib.parse.unquote(value)
+            return parse.unquote(value)
 
         @property
         def File(self):
@@ -92,7 +94,7 @@ def sca_suppress_init(d, suppress_extra, suppress_file, file_trace=True):
         def __init__(self, d, suppress_extra, suppress_file, file_trace=True):
             self.__Items = self.__add_global_items(d, suppress_extra, suppress_file) + self.__add_local_items(d)
             # automatically set to false if running on image
-            self.__filetrace = file_trace and not bb.data.inherits_class('image', d)
+            self.__filetrace = file_trace and not bb.data.inherits_class('image', d) and not d.getVar("SCA_NO_TRACEFILES")
             self.__tracedfiles = set()
             if os.path.exists(d.getVar("SCA_TRACEFILES_LIST") or "/does/not/exist") and self.__filetrace:
                 _valid_package = d.expand("${SCA_TRACEFILES_PKGS}").split(" ")

--- a/classes/sca-systemdlint-core.bbclass
+++ b/classes/sca-systemdlint-core.bbclass
@@ -38,7 +38,7 @@ def do_sca_conv_systemdlint(d):
         "info": "info"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_SYSTEMDLINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_SYSTEMDLINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/systemdlint-${SCA_MODE}-suppress"),
                                   file_trace=False)
     _findings = []
@@ -94,7 +94,7 @@ python do_sca_systemdlint() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "systemdlint", get_fatal_entries(d, "SCA_SYSTEMDLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "systemdlint", get_fatal_entries(d, clean_split(d, "SCA_SYSTEMDLINT_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/systemdlint-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-systemdlint-image.bbclass
+++ b/classes/sca-systemdlint-image.bbclass
@@ -7,6 +7,7 @@ inherit sca-systemdlint-core
 
 SCA_SYSTEMDLINT_SOURCES_DIR = "${SCA_SOURCES_DIR}"
 
+do_sca_systemdlint[nosdkgen] = "1"
 addtask do_sca_systemdlint before do_sca_deploy after do_image
 
 DEPENDS += "sca-image-systemdlint-rules-native"

--- a/classes/sca-tiger-image.bbclass
+++ b/classes/sca-tiger-image.bbclass
@@ -31,7 +31,7 @@ def do_sca_conv_tiger(d):
         "WARN" : "warning"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_TIGER_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_TIGER_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/tiger-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -79,11 +79,12 @@ fakeroot python do_sca_tiger() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "tiger", get_fatal_entries(d, "SCA_TIGER_EXTRA_FATAL",
+    sca_task_aftermath(d, "tiger", get_fatal_entries(d, clean_split(d, "SCA_TIGER_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/tiger-${SCA_MODE}-fatal")))
 }
 
 do_sca_tiger[doc] = "Run audit with tiger on image"
+do_sca_tiger[nosdkgen] = "1"
 addtask do_sca_tiger before do_sca_deploy after do_image
 
 DEPENDS += "sca-image-tiger-rules-native"

--- a/classes/sca-tlv-core.bbclass
+++ b/classes/sca-tlv-core.bbclass
@@ -27,7 +27,7 @@ def do_sca_conv_tlv(d):
         "Duplicate" : "error",
         "TooLessVariation" : "warning"
     }
-    _suppress = sca_suppress_init(d, "", None)
+    _suppress = sca_suppress_init(d, clean_split(d, ""), None)
     _findings = []
 
     if os.path.exists(sca_raw_result_file(d, "tlv")):
@@ -84,7 +84,7 @@ python do_sca_tlv_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "tlv", get_fatal_entries(d, "", None))
+    sca_task_aftermath(d, "tlv", get_fatal_entries(d, clean_split(d, ""), None))
 }
 
 DEPENDS += "python3-tlv-native"

--- a/classes/sca-tracefiles.bbclass
+++ b/classes/sca-tracefiles.bbclass
@@ -82,6 +82,7 @@ python do_sca_tracefiles() {
         json.dump(sca_get_trace_files(d), o)
 }
 
+do_sca_tracefiles[nosdkgen] = "1"
 addtask do_sca_tracefiles after do_install before do_package
 
 DEPENDS += "tracefiles-native"

--- a/classes/sca-tscancode.bbclass
+++ b/classes/sca-tscancode.bbclass
@@ -59,7 +59,7 @@ def do_sca_conv_tscancode(d):
         "Information" : "info"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_TSCANCODE_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_TSCANCODE_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/tscancode-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -147,7 +147,7 @@ python do_sca_tscancode_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "tscancode", get_fatal_entries(d, "SCA_TSCANCODE_EXTRA_FATAL",
+    sca_task_aftermath(d, "tscancode", get_fatal_entries(d, clean_split(d, "SCA_TSCANCODE_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/tscancode-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-upc-image.bbclass
+++ b/classes/sca-upc-image.bbclass
@@ -75,7 +75,7 @@ def do_sca_conv_upc(d):
         "W" : "warning"
     }
 
-    _suppress = sca_suppress_init(d, "SCA_UPC_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_UPC_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/upc-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -120,11 +120,12 @@ fakeroot python do_sca_upc() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "upc", get_fatal_entries(d, "SCA_UPC_EXTRA_FATAL",
+    sca_task_aftermath(d, "upc", get_fatal_entries(d, clean_split(d, "SCA_UPC_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/upc-${SCA_MODE}-fatal")))
 }
 
 do_sca_upc[doc] = "Find priviledge esacalation vectors in image"
+do_sca_upc[nosdkgen] = "1"
 addtask do_sca_upc before do_sca_deploy after do_image
 
 DEPENDS += "sca-image-upc-rules-native"

--- a/classes/sca-vulture-core.bbclass
+++ b/classes/sca-vulture-core.bbclass
@@ -23,7 +23,7 @@ def do_sca_conv_vulture(d):
     package_name = d.getVar("PN")
     buildpath = d.getVar("SCA_SOURCES_DIR")
 
-    _suppress = sca_suppress_init(d, "", None)
+    _suppress = sca_suppress_init(d, clean_split(d, ""), None)
 
     pattern = r"^(?P<file>.*):(?P<line>\d+):\s*(?P<message>.*)"
 
@@ -86,7 +86,7 @@ python do_sca_vulture_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "vulture", get_fatal_entries(d, "SCA_VULTURE_EXTRA_FATAL",
+    sca_task_aftermath(d, "vulture", get_fatal_entries(d, clean_split(d, "SCA_VULTURE_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/vulture-${SCA_MODE}-fatal")))
 }
 

--- a/classes/sca-xmllint-core.bbclass
+++ b/classes/sca-xmllint-core.bbclass
@@ -27,7 +27,7 @@ def do_sca_conv_xmllint(d):
 
     pattern = r"^(?P<file>.*):(?P<line>\d+):\s+(?P<id>.*)\s+error\s+:\s+(?P<msg>.*)"
 
-    _suppress = sca_suppress_init(d, "SCA_XMLLINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_XMLLINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/xmllint-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -82,6 +82,6 @@ python do_sca_xmllint_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "xmllint", get_fatal_entries(d, "SCA_XMLLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "xmllint", get_fatal_entries(d, clean_split(d, "SCA_XMLLINT_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/xmllint-${SCA_MODE}-fatal")))
 }

--- a/classes/sca-yamllint-core.bbclass
+++ b/classes/sca-yamllint-core.bbclass
@@ -34,7 +34,7 @@ def do_sca_conv_yamllint(d):
         "warning" : "warning",
     }
 
-    _suppress = sca_suppress_init(d, "SCA_YAMLLINT_EXTRA_SUPPRESS",
+    _suppress = sca_suppress_init(d, clean_split(d, "SCA_YAMLLINT_EXTRA_SUPPRESS"),
                                   d.expand("${STAGING_DATADIR_NATIVE}/yamllint-${SCA_MODE}-suppress"))
     _findings = []
 
@@ -89,6 +89,6 @@ python do_sca_yamllint_core_report() {
     with open(d.getVar("SCA_DATAMODEL_STORAGE"), "w") as o:
         o.write(dm_output)
 
-    sca_task_aftermath(d, "yamllint", get_fatal_entries(d, "SCA_YAMLLINT_EXTRA_FATAL",
+    sca_task_aftermath(d, "yamllint", get_fatal_entries(d, clean_split(d, "SCA_YAMLLINT_EXTRA_FATAL"),
                        d.expand("${STAGING_DATADIR_NATIVE}/yamllint-${SCA_MODE}-fatal")))
 }

--- a/recipes-sca/sudokiller/sudokiller_20220211.bb
+++ b/recipes-sca/sudokiller/sudokiller_20220211.bb
@@ -6,7 +6,7 @@ DEFAULT_PREFERENCE = "${SCA_DEFAULT_PREFERENCE}"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f45999e825d6792e32a1cbadd968b1b7"
 
-SRC_URI = "git://github.com/TH3xACE/SUDO_KILLER.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/TH3xACE/SUDO_KILLER.git;protocol=https;branch=V2"
 SRCREV = "51e3de24c921b9d89b8925e0d00e228575ea5ae9"
 UPSTREAM_CHECK_COMMITS = "1"
 


### PR DESCRIPTION
I ran across the sca-helper's do_sca_get_sources-task issues on a kirkstone build (I can't move to a newer release I'm afraid).

I also had to pick [classes: set flags and enable parsing](https://github.com/priv-kweihmann/meta-sca/commit/e1b6bdd07bc700fb4fb3d936f35267d94dd80d71) in order to apply [sca-helper: ignore all non existing files](https://github.com/priv-kweihmann/meta-sca/commit/94c0a89aa46fe91baf222a2f4315db6ed417a0b8) but that shouldn't hurt.

Hope we can get this in, that'd help me keep things sane in our repositories.

WIP ... trying to get the test suite to run .. it doesn't look like it's still in working condition ... looks to me like it's broken for kirkstone branch :/

Mandatory legal disclaimer from my company:

The program was tested solely for our own use cases, which might differ from yours.

<sub>Mark Schmitt [mark.schmitt@mercedes-benz.com](mailto:mark.schmitt@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sub>