### PR TITLE
python3-flake8-print-native do_install:append(): delete LICENSE rename

### DIFF
--- a/recipes-python/python-flake8-print-native/python3-flake8-print-native_5.0.0.bb
+++ b/recipes-python/python-flake8-print-native/python3-flake8-print-native_5.0.0.bb
@@ -21,7 +21,6 @@ inherit python_poetry_core
 inherit_defer native
 
 do_install:append() {
-    mv -f ${D}${PYTHON_SITEPACKAGES_DIR}/LICENCE ${D}${PYTHON_SITEPACKAGES_DIR}/LICENCE.${PN}
     rm -f ${D}${PYTHON_SITEPACKAGES_DIR}/pyproject.toml
 }
 


### PR DESCRIPTION
Removed command to rename LICENSE to LICENSE.${PN} due to this error:

    mv: cannot stat
    '/home/geoff/yocto-master/build/tmp/work/x86_64-linux/python3-flake8-print-native/5.0.0/recipe-sysroot-native/usr/lib/python3.13/site-packages/LICENCE':
    No such file or directory